### PR TITLE
出欠一覧表示（修正後）

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -339,6 +339,68 @@ a {
   position: relative;
 }
 
+/* 出欠一覧 */
+.atte-main {
+  background-color: #ffffe0;
+}
+
+.atte-contents {
+  padding: 0 0 0 40px;
+  display: flex;
+  
+}
+
+.atte-name {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 70px;
+}
+
+.atte-presence {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 50px;
+}
+
+.atte-bath {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 120px;
+}
+
+.atte-bf {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 160px;
+}
+
+.atte-temper {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 100px;
+}
+
+.atte-created {
+  padding: 3px 5px 0 6px;
+  background-color: #fff799;
+  border: 1px solid #3cb371;
+  width: 200px;
+}
+
+table th {/*table内のthに対して*/
+  padding: 10px;/*上下左右10pxずつ*/
+  border: solid 1px black;
+}
+
+table td {/*table内のtdに対して*/
+  padding: 3px 10px;/*上下3pxで左右10px*/
+  border: solid 1px black;
+}
 
 /* タブレット対応 */
 @media (max-width: 1024px) {

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -1,8 +1,69 @@
+
+<div class="atte-main">
+<h1 class>出欠一覧</h1>
+<br>
+  <div class="atte-contents">
+    <div class="atte-name">
+    名前
+    </div>
+    <div class="atte-presence">
+    出欠
+    </div>
+    <div class="atte-bath">
+    お風呂
+    </div>
+    <div class="atte-bf">
+    朝ご飯
+    </div>
+    <div class="atte-temper">
+    体温
+    </div>
+    <div class="atte-created">
+    投稿時間</p>
+    </div>
+  </div>
+    
 <% @attendances.each do |attendance| %>
-  <p><%= attendance.user.name %>
-  <%= attendance.presence.name %>
-  <%= attendance.bath.name %>
-  <%= attendance.breakfast.name %>
-  <%= attendance.temperture.name %>
-  <%= l attendance.created_at %></p>
-<% end %>
+<div class="atte-contents">
+
+    <div class="atte-name">
+      <p><%= attendance.user.name %>
+    </div>
+    <div class="atte-presence">
+      <%= attendance.presence.name %>
+      </div>
+      <div class="atte-bath">
+      <%= attendance.bath.name %>
+      </div>
+      <div class="atte-bf">
+      <%= attendance.breakfast.name %>
+      </div>
+      <div class="atte-temper">
+      <%= attendance.temperture.name %>
+      </div>
+      <div class="atte-created">
+      <%= l attendance.created_at %></p>
+      </div>
+  </div>
+  <% end %>
+</div>
+<br>
+<div class="atte-main">
+<div class="atte-contents">
+<table border="1">
+  <tr>
+    <th>名前</th><th>出欠</th><th>お風呂</th><th>朝ご飯</th><th>体温</th><th>投稿時間</th>
+  </tr>
+  <% @attendances.each do |attendance| %>
+  <tr>
+    <td><%= attendance.user.name %></td>
+    <td><%= attendance.presence.name %></td>
+    <td><%= attendance.bath.name %></td>
+    <td><%= attendance.breakfast.name %></td>
+    <td><%= attendance.temperture.name %></td>
+    <td><%= l attendance.created_at %></td>
+  </tr>
+  <% end %>
+</table>
+</div>
+</div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -28,7 +28,7 @@
     <div class="d-flex justify-content-center">
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://2.bp.blogspot.com/-4FpV36b5_NY/Vlmd4x-3JGI/AAAAAAAA1Hg/x9VhApI_oDI/s150/christmas_mark14_rabbit.png" class="card-img-top" alt="...">
+        <img src="http://3.bp.blogspot.com/-AC5vmYBscMw/UZRWELc3AzI/AAAAAAAASuk/MNSaQk3flwQ/s180-c/hanami_usagi.png" class="card-img-top" alt="...">
           <div class="card-body">
               <h5 class="card-title">お知らせを見る</h5>
               <p class="card-text"></p>
@@ -38,7 +38,7 @@
       </div>
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://2.bp.blogspot.com/-Dd3EuGWMOys/Vlmd3f4PM6I/AAAAAAAA1HI/nPfo227Qxbo/s150/christmas_mark10_pig.png" class="card-img-top" alt="...">
+        <img src="http://2.bp.blogspot.com/-5Fk5W1srxDo/UZRWCaNXFXI/AAAAAAAASuA/c0YSomHMfhQ/s180-c/hanami_inu.png" class="card-img-top" alt="...">
           <div class="card-body">
               <h5 class="card-title">メッセージを送る</h5>
               <p class="card-text"></p>
@@ -48,7 +48,7 @@
       </div>
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://2.bp.blogspot.com/-eijm4v9_9Nk/Vlmd4YhYQWI/AAAAAAAA1HY/3bLT-7zmcZw/s150/christmas_mark12_lion.png" class="card-img-top" alt="...">
+        <img src="http://2.bp.blogspot.com/-Y_FYUDciASI/UZRWDTu8vgI/AAAAAAAASuQ/aOwVwq-FtBE/s180-c/hanami_neko.png" class="card-img-top" alt="...">
           <div class="card-body">
             <h5 class="card-title">連絡帳を書く</h5>
             <p class="card-text"></p>
@@ -63,7 +63,7 @@
     <div class="d-flex justify-content-center">
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://3.bp.blogspot.com/-fh7os1Nyf-M/VlmdzhnCGbI/AAAAAAAA1GM/LPvGPq9xfEY/s150/christmas_mark01_santa.png" class="card-img-top" alt="...">
+        <img src="http://4.bp.blogspot.com/-JpovmLbHnKs/UZRWDZmapsI/AAAAAAAASuM/-YEd4TDlmX0/s180-c/hanami_kuma.png" class="card-img-top" alt="...">
           <div class="card-body">
             <h5 class="card-title">お知らせを投稿する</h5>
             <p class="card-text"></p>
@@ -73,7 +73,7 @@
       </div>
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://3.bp.blogspot.com/-XwDUSEwBNjQ/Vlmd2vjH3gI/AAAAAAAA1G4/P-Qh2Kx8NL8/s150/christmas_mark08_cat.png" class="card-img-top" alt="...">
+        <img src="http://4.bp.blogspot.com/-4_mKp1Q71M0/UZRWEUWc4fI/AAAAAAAASuo/9AV4UUQz8l0/s180-c/hanami_zou.png" class="card-img-top" alt="...">
           <div class="card-body">
             <h5 class="card-title">メッセージを確認する</h5>
             <p class="card-text"></p>
@@ -83,7 +83,7 @@
       </div>
       <div class="nav__btn">
         <div class="card" style="width: 18rem;">
-        <img src="https://3.bp.blogspot.com/-XmM8F0CZmbs/Vlmd1eEkYsI/AAAAAAAA1Go/ll3rMfNPQV8/s150/christmas_mark05_snowman.png" class="card-img-top" alt="...">
+        <img src="https://3.bp.blogspot.com/-vhmBkneKWxM/VKTgi71CkvI/AAAAAAAAqUw/-bTdgeat85E/s180-c/pyoko04_sakura.png" class="card-img-top" alt="...">
           <div class="card-body">
             <h5 class="card-title">出欠一覧を見る</h5>
             <p class="card-text"></p>


### PR DESCRIPTION
# What
- 出欠一覧表示を表形式に変更しました。
- どちらの表を採用するか迷っているため、２つ表示されています。後ほど一つに統一します。

# Why
- 文字が無地の画面に並んでいたので、一覧表で表示することにより見やすくなりました。
- tableタグを使用することにより、簡易に表を作成できました。